### PR TITLE
Add compilation test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # USACO-Solutions
-Just my solutions -- probably not the best ;) 
+Just my solutions -- probably not the best ;)
+
+## Building all solutions
+
+To ensure every C++ source compiles, run:
+
+```bash
+./scripts/build_all.sh
+```
+
+The script compiles each `.cpp` file with `g++` and exits with a non-zero status if any compilation fails.

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+for file in $(find . -name '*.cpp'); do
+    echo "Compiling $file"
+    g++ -std=c++17 -c "$file" -o /dev/null
+done
+
+echo "All files compiled successfully."


### PR DESCRIPTION
## Summary
- add `scripts/build_all.sh` to compile all C++ files with g++
- document how to run the build script

## Testing
- `./scripts/build_all.sh > /tmp/build_log.txt`


------
https://chatgpt.com/codex/tasks/task_e_68405f4e8c3483338c9fe3190ebccc2b